### PR TITLE
Set the `rcond` parameter of numpy lstsq() to `-1`

### DIFF
--- a/big_o/complexities.py
+++ b/big_o/complexities.py
@@ -33,7 +33,7 @@ class ComplexityClass(object):
         """
         x = self._transform_n(n)
         y = self._transform_time(t)
-        coeff, residuals, rank, s = np.linalg.lstsq(x, y)
+        coeff, residuals, rank, s = np.linalg.lstsq(x, y, rcond=-1)
         self.coeff = coeff
         return residuals[0]
 


### PR DESCRIPTION
It is because of FutureWarning:
To use the future default and silence this warning we advise to pass `rcond=None`,
to keep using the old, explicitly pass `rcond=-1`