### PR TITLE
Add Install Requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 
 with open('README.rst') as readme_file:
@@ -15,4 +15,5 @@ setup(
     license='LICENSE.txt',
     long_description=long_description,
     packages=['big_o', 'big_o.test'],
+    install_requires=['numpy']
 )


### PR DESCRIPTION
Uses setuptools' install-requires to check for numpy and install if necessary during installs of big_O package. Resolves #18.  