### PR TITLE
Adding return_raw_data param to big_o function

### DIFF
--- a/big_o/big_o.py
+++ b/big_o/big_o.py
@@ -79,6 +79,11 @@ def infer_big_o_class(ns, time, classes=ALL_CLASSES, verbose=False, return_raw_d
     verbose -- If True, print parameters and residuals of the fit for each
                complexity class
 
+    return_raw_data -- If True, it returns the measure points and its corresponding
+                       execution times as part of the fitted complexity classes. Each
+                       dictionary will have the structure: 
+                       {residuals = <float>, measures = [<int>+], times = [<float>+]}
+
     Output:
     -------
 

--- a/big_o/big_o.py
+++ b/big_o/big_o.py
@@ -62,7 +62,7 @@ def measure_execution_time(func, data_generator,
     return ns, execution_time
 
 
-def infer_big_o_class(ns, time, classes=ALL_CLASSES, verbose=False, return_raw_data=False):
+def infer_big_o_class(ns, time, classes=ALL_CLASSES, verbose=False):
     """Infer the complexity class from execution times.
 
     Input:
@@ -78,11 +78,6 @@ def infer_big_o_class(ns, time, classes=ALL_CLASSES, verbose=False, return_raw_d
 
     verbose -- If True, print parameters and residuals of the fit for each
                complexity class
-
-    return_raw_data -- If True, it returns the measure points and its corresponding
-                       execution times as part of the fitted complexity classes. Each
-                       dictionary will have the structure: 
-                       {residuals = <float>, measures = [<int>+], times = [<float>+]}
 
     Output:
     -------
@@ -100,8 +95,7 @@ def infer_big_o_class(ns, time, classes=ALL_CLASSES, verbose=False, return_raw_d
     for class_ in classes:
         inst = class_()
         residuals = inst.fit(ns, time)
-        fitted[inst] = residuals if not return_raw_data else {
-            'residuals': residuals, 'measures': ns, 'times': time}
+        fitted[inst] = residuals
 
         # NOTE: subtract 1e-6 for tiny preference for simpler methods
         # TODO: improve simplicity bias (AIC/BIC)?
@@ -147,10 +141,10 @@ def big_o(func, data_generator,
     verbose -- If True, print parameters and residuals of the fit for each
                complexity class
 
-    return_raw_data -- If True, it returns the measure points and its corresponding
-                       execution times as part of the fitted complexity classes. Each
-                       dictionary will have the structure: 
-                       {residuals = <float>, measures = [<int>+], times = [<float>+]}
+    return_raw_data -- If True, the function returns the measure points and its 
+                       corresponding execution times as part of the fitted dictionary
+                       of complexity classes. When this flag is true, fitted will 
+                       contain the entries: {'measures': [<int>+], 'times': [<float>+]}
 
     Output:
     -------
@@ -165,4 +159,10 @@ def big_o(func, data_generator,
     ns, time = measure_execution_time(func, data_generator,
                                       min_n, max_n, n_measures, n_repeats,
                                       n_timings)
-    return infer_big_o_class(ns, time, classes, verbose=verbose, return_raw_data=return_raw_data)
+    best, fitted = infer_big_o_class(ns, time, classes, verbose=verbose)
+
+    if return_raw_data:
+        fitted['measures'] = ns
+        fitted['times'] = time
+
+    return best, fitted

--- a/big_o/big_o.py
+++ b/big_o/big_o.py
@@ -62,7 +62,7 @@ def measure_execution_time(func, data_generator,
     return ns, execution_time
 
 
-def infer_big_o_class(ns, time, classes=ALL_CLASSES, verbose=False):
+def infer_big_o_class(ns, time, classes=ALL_CLASSES, verbose=False, return_raw_data=False):
     """Infer the complexity class from execution times.
 
     Input:
@@ -95,7 +95,8 @@ def infer_big_o_class(ns, time, classes=ALL_CLASSES, verbose=False):
     for class_ in classes:
         inst = class_()
         residuals = inst.fit(ns, time)
-        fitted[inst] = residuals
+        fitted[inst] = residuals if not return_raw_data else {
+            'residuals': residuals, 'measures': ns, 'times': time}
 
         # NOTE: subtract 1e-6 for tiny preference for simpler methods
         # TODO: improve simplicity bias (AIC/BIC)?
@@ -109,7 +110,7 @@ def infer_big_o_class(ns, time, classes=ALL_CLASSES, verbose=False):
 
 def big_o(func, data_generator,
           min_n=100, max_n=100000, n_measures=10,
-          n_repeats=1, n_timings=1, classes=ALL_CLASSES, verbose=False):
+          n_repeats=1, n_timings=1, classes=ALL_CLASSES, verbose=False, return_raw_data=False):
     """ Estimate time complexity class of a function from execution time.
 
     Input:
@@ -141,6 +142,11 @@ def big_o(func, data_generator,
     verbose -- If True, print parameters and residuals of the fit for each
                complexity class
 
+    return_raw_data -- If True, it returns the measure points and its corresponding
+                       execution times as part of the fitted complexity classes. Each
+                       dictionary will have the structure: 
+                       {residuals = <float>, measures = [<int>+], times = [<float>+]}
+
     Output:
     -------
 
@@ -154,4 +160,4 @@ def big_o(func, data_generator,
     ns, time = measure_execution_time(func, data_generator,
                                       min_n, max_n, n_measures, n_repeats,
                                       n_timings)
-    return infer_big_o_class(ns, time, classes, verbose=verbose)
+    return infer_big_o_class(ns, time, classes, verbose=verbose, return_raw_data=return_raw_data)

--- a/big_o/big_o.py
+++ b/big_o/big_o.py
@@ -144,7 +144,8 @@ def big_o(func, data_generator,
     return_raw_data -- If True, the function returns the measure points and its 
                        corresponding execution times as part of the fitted dictionary
                        of complexity classes. When this flag is true, fitted will 
-                       contain the entries: {'measures': [<int>+], 'times': [<float>+]}
+                       contain the entries: 
+                       {... 'measures': [<int>+], 'times': [<float>+] ...}
 
     Output:
     -------

--- a/big_o/test/test_big_o.py
+++ b/big_o/test/test_big_o.py
@@ -117,27 +117,36 @@ class TestBigO(unittest.TestCase):
             self.assertIsInstance(v, np.float64)
 
     def test_big_o_return_raw_data_true(self):
-        def dummy_linear_function(n):
-            for _ in range(n):
-                # Dummy operation with constant complexity.
-                8282828 * 2322
+        def dummy(n):
+            time.sleep(0.001)
+
+        n_measures = 10
+        n_repeats = 5
+        n_timings = 3
 
         _, fitted = big_o.big_o(
-            dummy_linear_function,
+            dummy,
             datagen.n_,
             min_n=100,
-            max_n=10000,
-            n_measures=25,
-            n_repeats=10,
-            n_timings=10,
+            max_n=1000,
+            n_measures=n_measures,
+            n_repeats=n_repeats,
+            n_timings=n_timings,
             return_raw_data=True)
 
-        for _, v in fitted.items():
-            self.assertIsInstance(v, dict)
-            keys = v.keys()
-            self.assertIn('residuals', keys)
-            self.assertIsInstance(v['residuals'], np.float64)
-            self.assertIn('measures', keys)
-            self.assertEqual(len(v['measures']), 25)
-            self.assertIn('times', keys)
-            self.assertEqual(len(v['times']), 25)
+        for k, v in fitted.items():
+            if isinstance(k, compl.ComplexityClass):
+                self.assertIsInstance(v, np.float64)
+        
+        self.assertIn('measures', fitted)
+        measures = fitted['measures']
+        self.assertEqual(len(measures), n_measures)
+        for i in range(1, n_measures):
+            self.assertGreater(measures[i], measures[i-1])
+
+        self.assertIn('times', fitted)
+        times = fitted['times']
+        n_times = len(times)
+        self.assertEqual(n_times, 10)
+        for t in times:
+            self.assertGreaterEqual(t, 0.001 * n_repeats)

--- a/big_o/test/test_big_o.py
+++ b/big_o/test/test_big_o.py
@@ -78,3 +78,66 @@ class TestBigO(unittest.TestCase):
                 n_timings=10,
             )
             self.assertEqual(class_, res_class.__class__)
+
+    def test_big_o_return_raw_data_default(self):
+        def dummy_linear_function(n):
+            for _ in range(n):
+                # Dummy operation with constant complexity.
+                8282828 * 2322
+
+        _, fitted = big_o.big_o(
+            dummy_linear_function,
+            datagen.n_,
+            min_n=100,
+            max_n=10000,
+            n_measures=25,
+            n_repeats=10,
+            n_timings=10)
+
+        for _, v in fitted.items():
+            self.assertIsInstance(v, np.float64)
+
+    def test_big_o_return_raw_data_false(self):
+        def dummy_linear_function(n):
+            for _ in range(n):
+                # Dummy operation with constant complexity.
+                8282828 * 2322
+
+        _, fitted = big_o.big_o(
+            dummy_linear_function,
+            datagen.n_,
+            min_n=100,
+            max_n=10000,
+            n_measures=25,
+            n_repeats=10,
+            n_timings=10,
+            return_raw_data=False)
+
+        for _, v in fitted.items():
+            self.assertIsInstance(v, np.float64)
+
+    def test_big_o_return_raw_data_true(self):
+        def dummy_linear_function(n):
+            for _ in range(n):
+                # Dummy operation with constant complexity.
+                8282828 * 2322
+
+        _, fitted = big_o.big_o(
+            dummy_linear_function,
+            datagen.n_,
+            min_n=100,
+            max_n=10000,
+            n_measures=25,
+            n_repeats=10,
+            n_timings=10,
+            return_raw_data=True)
+
+        for _, v in fitted.items():
+            self.assertIsInstance(v, dict)
+            keys = v.keys()
+            self.assertIn('residuals', keys)
+            self.assertIsInstance(v['residuals'], np.float64)
+            self.assertIn('measures', keys)
+            self.assertEqual(len(v['measures']), 25)
+            self.assertIn('times', keys)
+            self.assertEqual(len(v['times']), 25)

--- a/big_o/test/test_big_o.py
+++ b/big_o/test/test_big_o.py
@@ -146,7 +146,6 @@ class TestBigO(unittest.TestCase):
 
         self.assertIn('times', fitted)
         times = fitted['times']
-        n_times = len(times)
-        self.assertEqual(n_times, 10)
+        self.assertEqual(len(times), n_measures)
         for t in times:
             self.assertGreaterEqual(t, 0.001 * n_repeats)


### PR DESCRIPTION
Hi, thanks a lot for this great lib. I took the liberty of adding a new flag parameter `return_raw_data` to the `big_o` function to return the raw data  (both measures and times) used to fit the models. This way the data can be used to draw plots or run further analysis. I tried to do it in a way it doesn't break backwards compatibility. Hope you find it useful.