### PR TITLE
class orderings

### DIFF
--- a/big_o/complexities.py
+++ b/big_o/complexities.py
@@ -92,6 +92,12 @@ class ComplexityClass(object):
     def __ge__(self, other):
         return (self > other) or self == other
 
+    def __eq__(self, other):
+        return self.order == other.order
+
+    def __hash__(self):
+        return id(self)
+
 # --- Concrete implementations of the most popular complexity classes
 
 

--- a/big_o/complexities.py
+++ b/big_o/complexities.py
@@ -86,6 +86,11 @@ class ComplexityClass(object):
     def __lt__(self, other):
         return self.order < other.order
 
+    def __le__(self, other):
+        return (self < other) or self == other
+
+    def __le__(self, other):
+        return (self > other) or self == other
 
 # --- Concrete implementations of the most popular complexity classes
 

--- a/big_o/complexities.py
+++ b/big_o/complexities.py
@@ -80,10 +80,19 @@ class ComplexityClass(object):
         """
         return t
 
+    def __gt__(self, other):
+        return self.order > other.order
+
+    def __lt__(self, other):
+        return self.order < other.order
+
 
 # --- Concrete implementations of the most popular complexity classes
 
+
 class Constant(ComplexityClass):
+    order = 1
+
     def _transform_n(self, n):
         return np.ones((len(n), 1))
 
@@ -93,6 +102,8 @@ class Constant(ComplexityClass):
 
 
 class Linear(ComplexityClass):
+    order = 2
+
     def _transform_n(self, n):
         return np.vstack([np.ones(len(n)), n]).T
 
@@ -102,6 +113,8 @@ class Linear(ComplexityClass):
 
 
 class Quadratic(ComplexityClass):
+    order = 4
+
     def _transform_n(self, n):
         return np.vstack([np.ones(len(n)), n * n]).T
 
@@ -111,6 +124,8 @@ class Quadratic(ComplexityClass):
 
 
 class Cubic(ComplexityClass):
+    order = 5
+
     def _transform_n(self, n):
         return np.vstack([np.ones(len(n)), n ** 3]).T
 
@@ -120,6 +135,8 @@ class Cubic(ComplexityClass):
 
 
 class Logarithmic(ComplexityClass):
+    order = 2
+
     def _transform_n(self, n):
         return np.vstack([np.ones(len(n)), np.log(n)]).T
 
@@ -129,6 +146,8 @@ class Logarithmic(ComplexityClass):
 
 
 class Linearithmic(ComplexityClass):
+    order = 3
+
     def _transform_n(self, n):
         return np.vstack([np.ones(len(n)), n * np.log(n)]).T
 
@@ -138,6 +157,8 @@ class Linearithmic(ComplexityClass):
 
 
 class Polynomial(ComplexityClass):
+    order = 6
+
     def _transform_n(self, n):
         return np.vstack([np.ones(len(n)), np.log(n)]).T
 
@@ -150,6 +171,8 @@ class Polynomial(ComplexityClass):
 
 
 class Exponential(ComplexityClass):
+    order = 7
+
     def _transform_n(self, n):
         return np.vstack([np.ones(len(n)), n]).T
 

--- a/big_o/complexities.py
+++ b/big_o/complexities.py
@@ -96,7 +96,7 @@ class ComplexityClass(object):
 
 
 class Constant(ComplexityClass):
-    order = 1
+    order = 10
 
     def _transform_n(self, n):
         return np.ones((len(n), 1))
@@ -107,7 +107,7 @@ class Constant(ComplexityClass):
 
 
 class Linear(ComplexityClass):
-    order = 3
+    order = 30
 
     def _transform_n(self, n):
         return np.vstack([np.ones(len(n)), n]).T
@@ -118,7 +118,7 @@ class Linear(ComplexityClass):
 
 
 class Quadratic(ComplexityClass):
-    order = 5
+    order = 50
 
     def _transform_n(self, n):
         return np.vstack([np.ones(len(n)), n * n]).T
@@ -129,7 +129,7 @@ class Quadratic(ComplexityClass):
 
 
 class Cubic(ComplexityClass):
-    order = 6
+    order = 60
 
     def _transform_n(self, n):
         return np.vstack([np.ones(len(n)), n ** 3]).T
@@ -140,7 +140,7 @@ class Cubic(ComplexityClass):
 
 
 class Logarithmic(ComplexityClass):
-    order = 2
+    order = 20
 
     def _transform_n(self, n):
         return np.vstack([np.ones(len(n)), np.log(n)]).T
@@ -151,7 +151,7 @@ class Logarithmic(ComplexityClass):
 
 
 class Linearithmic(ComplexityClass):
-    order = 4
+    order = 40
 
     def _transform_n(self, n):
         return np.vstack([np.ones(len(n)), n * np.log(n)]).T
@@ -162,7 +162,7 @@ class Linearithmic(ComplexityClass):
 
 
 class Polynomial(ComplexityClass):
-    order = 7
+    order = 70
 
     def _transform_n(self, n):
         return np.vstack([np.ones(len(n)), np.log(n)]).T
@@ -176,7 +176,7 @@ class Polynomial(ComplexityClass):
 
 
 class Exponential(ComplexityClass):
-    order = 8
+    order = 80
 
     def _transform_n(self, n):
         return np.vstack([np.ones(len(n)), n]).T

--- a/big_o/complexities.py
+++ b/big_o/complexities.py
@@ -89,7 +89,7 @@ class ComplexityClass(object):
     def __le__(self, other):
         return (self < other) or self == other
 
-    def __le__(self, other):
+    def __ge__(self, other):
         return (self > other) or self == other
 
 # --- Concrete implementations of the most popular complexity classes

--- a/big_o/complexities.py
+++ b/big_o/complexities.py
@@ -107,7 +107,7 @@ class Constant(ComplexityClass):
 
 
 class Linear(ComplexityClass):
-    order = 2
+    order = 3
 
     def _transform_n(self, n):
         return np.vstack([np.ones(len(n)), n]).T
@@ -118,7 +118,7 @@ class Linear(ComplexityClass):
 
 
 class Quadratic(ComplexityClass):
-    order = 4
+    order = 5
 
     def _transform_n(self, n):
         return np.vstack([np.ones(len(n)), n * n]).T
@@ -129,7 +129,7 @@ class Quadratic(ComplexityClass):
 
 
 class Cubic(ComplexityClass):
-    order = 5
+    order = 6
 
     def _transform_n(self, n):
         return np.vstack([np.ones(len(n)), n ** 3]).T
@@ -151,7 +151,7 @@ class Logarithmic(ComplexityClass):
 
 
 class Linearithmic(ComplexityClass):
-    order = 3
+    order = 4
 
     def _transform_n(self, n):
         return np.vstack([np.ones(len(n)), n * np.log(n)]).T
@@ -162,7 +162,7 @@ class Linearithmic(ComplexityClass):
 
 
 class Polynomial(ComplexityClass):
-    order = 6
+    order = 7
 
     def _transform_n(self, n):
         return np.vstack([np.ones(len(n)), np.log(n)]).T
@@ -176,7 +176,7 @@ class Polynomial(ComplexityClass):
 
 
 class Exponential(ComplexityClass):
-    order = 7
+    order = 8
 
     def _transform_n(self, n):
         return np.vstack([np.ones(len(n)), n]).T

--- a/big_o/test/test_big_o.py
+++ b/big_o/test/test_big_o.py
@@ -44,13 +44,13 @@ class TestBigO(unittest.TestCase):
     def test_big_o(self):
         def dummy_linear_function(n):
             for i in range(n):
-                # Dummy operation with constant complexity.
+                # Dummy operation with linear complexity.
                 8282828 * 2322
 
         def dummy_quadratic_function(n):
             for i in range(n):
                 for j in range(n):
-                    # Dummy operation with constant complexity.
+                    # Dummy operation with quadratic complexity.
                     8282828 * 2322
 
         # In the best case, TimSort is linear, so we fix a random array to
@@ -64,7 +64,7 @@ class TestBigO(unittest.TestCase):
         desired = [
             (dummy_linear_function, compl.Linear, (100, 10000)),
             (lambda n: 1., compl.Constant, (1000, 10000)),
-            (dummy_quadratic_function, compl.Quadratic, (50, 200)),
+            (dummy_quadratic_function, compl.Quadratic, (50, 500)),
             (lambda n: np.sort(random_array[:n], kind='mergesort'),
              compl.Linearithmic, (100, random_array.shape[0])),
         ]
@@ -137,7 +137,7 @@ class TestBigO(unittest.TestCase):
         for k, v in fitted.items():
             if isinstance(k, compl.ComplexityClass):
                 self.assertIsInstance(v, np.float64)
-        
+
         self.assertIn('measures', fitted)
         measures = fitted['measures']
         self.assertEqual(len(measures), n_measures)

--- a/big_o/test/test_complexityclass_comparisons.py
+++ b/big_o/test/test_complexityclass_comparisons.py
@@ -1,0 +1,44 @@
+import unittest
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+
+from big_o.complexities import ComplexityClass
+
+
+class FirstComplexityClass(ComplexityClass):
+    order = 1
+
+
+class SecondComplexityClass(ComplexityClass):
+    order = 2
+
+
+FirstComplexity = FirstComplexityClass()
+SecondComplexity = SecondComplexityClass()
+
+
+class TestComplexities(unittest.TestCase):
+
+    def test_ge(self):
+        self.assertEqual(FirstComplexity >= SecondComplexity, False)
+        self.assertEqual(FirstComplexity >= FirstComplexity, True)
+        self.assertEqual(SecondComplexity >= FirstComplexity, True)
+
+    def test_le(self):
+        self.assertEqual(FirstComplexity <= SecondComplexity, True)
+        self.assertEqual(FirstComplexity <= FirstComplexity, True)
+        self.assertEqual(SecondComplexity <= FirstComplexity, False)
+
+    def test_l(self):
+        self.assertEqual(FirstComplexity < SecondComplexity, True)
+        self.assertEqual(FirstComplexity < FirstComplexity, False)
+        self.assertEqual(SecondComplexity < FirstComplexity, False)
+
+    def test_l(self):
+        self.assertEqual(FirstComplexity > SecondComplexity, False)
+        self.assertEqual(FirstComplexity > FirstComplexity, False)
+        self.assertEqual(SecondComplexity > FirstComplexity, True)
+
+    def test_eq(self):
+        self.assertEqual(FirstComplexity == SecondComplexity, False)
+        self.assertEqual(FirstComplexity == FirstComplexity, True)

--- a/big_o/test/test_complexityclass_comparisons.py
+++ b/big_o/test/test_complexityclass_comparisons.py
@@ -8,36 +8,47 @@ class FirstComplexityClass(ComplexityClass):
     order = 1
 
 
+class AltFirstComplexityClass(ComplexityClass):
+    order = 1
+
+
 class SecondComplexityClass(ComplexityClass):
     order = 2
 
 
-FirstComplexity = FirstComplexityClass()
-SecondComplexity = SecondComplexityClass()
-
-
 class TestComplexities(unittest.TestCase):
 
+    def setUp(self):
+        print('here')
+        self.first_complexity = FirstComplexityClass()
+        self.alt_first_complexity = AltFirstComplexityClass()
+        self.second_complexity = SecondComplexityClass()
+
     def test_ge(self):
-        self.assertEqual(FirstComplexity >= SecondComplexity, False)
-        self.assertEqual(FirstComplexity >= FirstComplexity, True)
-        self.assertEqual(SecondComplexity >= FirstComplexity, True)
+        self.assertFalse(self.first_complexity >= self.second_complexity)
+        self.assertTrue(self.second_complexity >= self.first_complexity)
+        self.assertTrue(self.first_complexity >= self.first_complexity)
+        self.assertTrue(self.alt_first_complexity >= self.first_complexity)
+        self.assertTrue(self.first_complexity >= self.alt_first_complexity)
 
     def test_le(self):
-        self.assertEqual(FirstComplexity <= SecondComplexity, True)
-        self.assertEqual(FirstComplexity <= FirstComplexity, True)
-        self.assertEqual(SecondComplexity <= FirstComplexity, False)
+        self.assertTrue(self.first_complexity <= self.second_complexity)
+        self.assertFalse(self.second_complexity <= self.first_complexity)
+        self.assertTrue(self.first_complexity <= self.first_complexity)
+        self.assertTrue(self.alt_first_complexity <= self.first_complexity)
+        self.assertTrue(self.first_complexity <= self.alt_first_complexity)
 
     def test_l(self):
-        self.assertEqual(FirstComplexity < SecondComplexity, True)
-        self.assertEqual(FirstComplexity < FirstComplexity, False)
-        self.assertEqual(SecondComplexity < FirstComplexity, False)
+        self.assertTrue(self.first_complexity < self.second_complexity)
+        self.assertFalse(self.second_complexity < self.first_complexity)
+        self.assertFalse(self.first_complexity < self.alt_first_complexity)
 
     def test_g(self):
-        self.assertEqual(FirstComplexity > SecondComplexity, False)
-        self.assertEqual(FirstComplexity > FirstComplexity, False)
-        self.assertEqual(SecondComplexity > FirstComplexity, True)
+        self.assertFalse(self.first_complexity > self.second_complexity)
+        self.assertTrue(self.second_complexity > self.first_complexity)
+        self.assertFalse(self.first_complexity > self.alt_first_complexity)
 
     def test_eq(self):
-        self.assertEqual(FirstComplexity == SecondComplexity, False)
-        self.assertEqual(FirstComplexity == FirstComplexity, True)
+        self.assertFalse(self.first_complexity == self.second_complexity)
+        self.assertTrue(self.first_complexity == self.first_complexity)
+        self.assertTrue(self.first_complexity == self.alt_first_complexity)

--- a/big_o/test/test_complexityclass_comparisons.py
+++ b/big_o/test/test_complexityclass_comparisons.py
@@ -34,7 +34,7 @@ class TestComplexities(unittest.TestCase):
         self.assertEqual(FirstComplexity < FirstComplexity, False)
         self.assertEqual(SecondComplexity < FirstComplexity, False)
 
-    def test_l(self):
+    def test_g(self):
         self.assertEqual(FirstComplexity > SecondComplexity, False)
         self.assertEqual(FirstComplexity > FirstComplexity, False)
         self.assertEqual(SecondComplexity > FirstComplexity, True)

--- a/big_o/test/test_complexityclass_comparisons.py
+++ b/big_o/test/test_complexityclass_comparisons.py
@@ -1,5 +1,4 @@
 import unittest
-import numpy as np
 
 from big_o.complexities import ComplexityClass
 
@@ -19,7 +18,6 @@ class SecondComplexityClass(ComplexityClass):
 class TestComplexities(unittest.TestCase):
 
     def setUp(self):
-        print('here')
         self.first_complexity = FirstComplexityClass()
         self.alt_first_complexity = AltFirstComplexityClass()
         self.second_complexity = SecondComplexityClass()

--- a/big_o/test/test_complexityclass_comparisons.py
+++ b/big_o/test/test_complexityclass_comparisons.py
@@ -1,6 +1,5 @@
 import unittest
 import numpy as np
-from numpy.testing import assert_array_almost_equal
 
 from big_o.complexities import ComplexityClass
 


### PR DESCRIPTION
This PR introduces the notion of ordering among complexity classes through a `__gt__` and `__lt__` method on the base complexity class. Each concrete implementation of a ComplexityClass is assumed to have an `order` attribute specifying their relative order among other implementations.