### PR TITLE
PyPI did not like the long description string

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,7 @@ Creating an array:
     (<class 'big_o.big_o.Constant'> ...)
 
 Additional examples
---------------
+-------------------
 
 We can compare the estimated time complexities of different Fibonacci number
 implementations. The naive implementation is exponential O(2^n). Since this

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,14 @@ with open('README.rst') as readme_file:
 
 setup(
     name='big_O',
-    version='0.10.0',
+    version='0.10.1',
     description='Empirical estimation of time complexity from execution time',
     author='Pietro Berkes',
     author_email='pietro.berkes@googlemail.com',
     url='https://github.com/pberkes/big_O',
     license='LICENSE.txt',
     long_description=long_description,
+    long_description_content_type='text/x-rst',
     packages=['big_o', 'big_o.test'],
     install_requires=['numpy']
 )


### PR DESCRIPTION
PyPI has become picky since the last time I used it, and refused the upload because one title underline was too short.

Fixed and checked with `twine check`