### PR TITLE
Remove vestigial `xrange` in a data generator function and add tests

### DIFF
--- a/big_o/datagen.py
+++ b/big_o/datagen.py
@@ -29,4 +29,4 @@ def large_integers(n):
 def strings(n, chars=string.ascii_letters):
     """ Return random string of N characters, sampled at random from `chars`.
     """
-    return ''.join([random.choice(chars) for i in xrange(n)])
+    return ''.join([random.choice(chars) for i in range(n)])

--- a/big_o/test/test_datagen.py
+++ b/big_o/test/test_datagen.py
@@ -1,0 +1,35 @@
+from big_o import datagen
+
+
+def test_n_():
+    assert datagen.n_(0) == 0
+    assert datagen.n_(3) == 3
+
+
+def test_range_n():
+    result = datagen.range_n(5, start=4)
+    expected = [4, 5, 6, 7, 8]
+    assert result == expected
+
+
+def test_integers():
+    n = 912
+    result = datagen.integers(n, min_=3, max_=12)
+    assert len(result) == n
+    assert min(result) >= 3
+    assert max(result) <= 12
+
+
+def test_large_integers():
+    n = 912
+    result = datagen.large_integers(n)
+    assert len(result) == n
+    assert max(result) > 1000000
+
+
+def test_strings():
+    chars = ['O', 'M', 'G']
+    result = datagen.strings(13, chars=chars)
+    assert isinstance(result, str)
+    assert len(result) == 13
+    assert len(set(result).difference(set(chars))) == 0

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.rst') as readme_file:
 
 setup(
     name='big_O',
-    version='0.10.1',
+    version='0.10.2',
     description='Empirical estimation of time complexity from execution time',
     author='Pietro Berkes',
     author_email='pietro.berkes@googlemail.com',


### PR DESCRIPTION
Fix #39 

- Fix `xrange` so it runs on Python 3+
- Add tests for the `datagen` module
- bump version number
