### PR TITLE
#43 Fix Polynomial.compute() and Exponential.compute() 

### DIFF
--- a/big_o/complexities.py
+++ b/big_o/complexities.py
@@ -50,12 +50,19 @@ class ComplexityClass(object):
             tot += self.coeff[i] * x[:, i]
         return self._inverse_transform_time(tot)
 
+    def coefficients(self):
+        """ Return coefficients in standard form. """
+        if self.coeff is None:
+            raise NotFittedError()
+        return self.coeff
+
     def __str__(self):
         prefix = '{}: '.format(self.__class__.__name__)
 
         if self.coeff is None:
             return prefix + ': not yet fitted'
-        return prefix + self.format_str().format(*tuple(self.coeff)) + ' (sec)'
+        return prefix + self.format_str().format(
+            *self.coefficients()) + ' (sec)'
 
     # --- abstract methods
 
@@ -189,6 +196,18 @@ class Polynomial(ComplexityClass):
     def format_str(cls):
         return 'time = {:.2G} * x^{:.2G}'
 
+    def coefficients(self):
+        """ Return coefficients in standard form. """
+        # The polynomial is stored in the format
+        # exp(a)*n^b where [a, b] are the coefficients
+        # Technical full format is exp(a+b*ln(n))
+        #
+        # Standard form is a*n^b
+        if self.coeff is None:
+            raise NotFittedError()
+
+        a, b = self.coeff
+        return np.exp(a), b
 
 class Exponential(ComplexityClass):
     order = 80
@@ -206,6 +225,18 @@ class Exponential(ComplexityClass):
     def format_str(cls):
         return 'time = {:.2G} * {:.2G}^n'
 
+    def coefficients(self):
+        """ Return coefficients in standard form. """
+        # The polynomial is stored in the format
+        # exp(a)*exp(b)^n where [a, b] are the coefficients
+        # Technical full format is exp(a+b*n)
+        #
+        # Standard form is a*b^n
+        if self.coeff is None:
+            raise NotFittedError()
+
+        a, b = self.coeff
+        return np.exp(a), np.exp(b)
 
 ALL_CLASSES = [Constant, Linear, Quadratic, Cubic, Polynomial,
                Logarithmic, Linearithmic, Exponential]

--- a/big_o/complexities.py
+++ b/big_o/complexities.py
@@ -60,7 +60,7 @@ class ComplexityClass(object):
         prefix = '{}: '.format(self.__class__.__name__)
 
         if self.coeff is None:
-            return prefix + ': not yet fitted'
+            return prefix + 'not yet fitted'
         return prefix + self.format_str().format(
             *self.coefficients()) + ' (sec)'
 

--- a/big_o/complexities.py
+++ b/big_o/complexities.py
@@ -48,7 +48,7 @@ class ComplexityClass(object):
         tot = 0
         for i in range(len(self.coeff)):
             tot += self.coeff[i] * x[:, i]
-        return tot
+        return self._inverse_transform_time(tot)
 
     def __str__(self):
         prefix = '{}: '.format(self.__class__.__name__)
@@ -77,6 +77,12 @@ class ComplexityClass(object):
     def _transform_time(self, t):
         """ Transform time as needed for fitting.
         (e.g., t->log(t)) for exponential class.
+        """
+        return t
+
+    def _inverse_transform_time(self, t):
+        """ Inverse transform time as needed for compute.
+        (e.g., t->exp(t)) for exponential class.
         """
         return t
 
@@ -176,6 +182,9 @@ class Polynomial(ComplexityClass):
     def _transform_time(self, t):
         return np.log(t)
 
+    def _inverse_transform_time(self, t):
+        return np.exp(t)
+
     @classmethod
     def format_str(cls):
         return 'time = {:.2G} * x^{:.2G}'
@@ -189,6 +198,9 @@ class Exponential(ComplexityClass):
 
     def _transform_time(self, t):
         return np.log(t)
+
+    def _inverse_transform_time(self, t):
+        return np.exp(t)
 
     @classmethod
     def format_str(cls):

--- a/big_o/complexities.py
+++ b/big_o/complexities.py
@@ -209,6 +209,7 @@ class Polynomial(ComplexityClass):
         a, b = self.coeff
         return np.exp(a), b
 
+
 class Exponential(ComplexityClass):
     order = 80
 
@@ -237,6 +238,7 @@ class Exponential(ComplexityClass):
 
         a, b = self.coeff
         return np.exp(a), np.exp(b)
+
 
 ALL_CLASSES = [Constant, Linear, Quadratic, Cubic, Polynomial,
                Logarithmic, Linearithmic, Exponential]

--- a/big_o/test/test_complexities.py
+++ b/big_o/test/test_complexities.py
@@ -24,7 +24,8 @@ class TestComplexities(unittest.TestCase):
             y = f(x)
             complexity = class_()
             complexity.fit(x, y)
-            assert_allclose(y, complexity.compute(x), err_msg = "compute() failed to match expected values for class %r" % class_)
+            assert_allclose(y, complexity.compute(x),
+                err_msg = "compute() failed to match expected values for class %r" % class_)
 
     def test_not_fitted(self):
         for class_ in complexities.ALL_CLASSES:

--- a/big_o/test/test_complexities.py
+++ b/big_o/test/test_complexities.py
@@ -27,8 +27,8 @@ class TestComplexities(unittest.TestCase):
             assert_array_almost_equal(complexity.compute(x), y, 10, "compute() failed to match expected values for class %r" % class_)
 
     def test_not_fitted(self):
-        linear = complexities.Linear()
-        self.assertRaises(complexities.NotFittedError, linear.compute, 100)
+        for class_ in complexities.ALL_CLASSES:
+            self.assertRaises(complexities.NotFittedError, class_().compute, 100)
 
     def test_str_includes_units(self):
         x = np.linspace(10, 100, 100)

--- a/big_o/test/test_complexities.py
+++ b/big_o/test/test_complexities.py
@@ -8,11 +8,23 @@ from big_o import complexities
 class TestComplexities(unittest.TestCase):
 
     def test_compute(self):
+        desired = [
+            (lambda x: 2.+x*0., complexities.Constant),
+            (lambda x: 5.*x+3., complexities.Linear),
+            (lambda x: 8.1*x**2.+0.9, complexities.Quadratic),
+            (lambda x: 1.0*x**3+11.0, complexities.Cubic),
+            (lambda x: 5.2*x**2.5, complexities.Polynomial),
+            (lambda x: 8.5*np.log(x)+99.0, complexities.Logarithmic),
+            (lambda x: 1.7*x*np.log(x)+2.74, complexities.Linearithmic),
+            (lambda x: 3.14**x, complexities.Exponential)
+        ]
+
         x = np.linspace(10, 100, 100)
-        y = 3.0 * x + 2.0
-        linear = complexities.Linear()
-        linear.fit(x, y)
-        assert_array_almost_equal(linear.compute(x), y, 10)
+        for f, class_ in desired:
+            y = f(x)
+            complexity = class_()
+            complexity.fit(x, y)
+            assert_array_almost_equal(complexity.compute(x), y, 10, "compute() failed to match expected values for class %r" % class_)
 
     def test_not_fitted(self):
         linear = complexities.Linear()

--- a/big_o/test/test_complexities.py
+++ b/big_o/test/test_complexities.py
@@ -1,6 +1,6 @@
 import unittest
 import numpy as np
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_allclose
 
 from big_o import complexities
 
@@ -24,7 +24,7 @@ class TestComplexities(unittest.TestCase):
             y = f(x)
             complexity = class_()
             complexity.fit(x, y)
-            assert_array_almost_equal(complexity.compute(x), y, 10, "compute() failed to match expected values for class %r" % class_)
+            assert_allclose(y, complexity.compute(x), err_msg = "compute() failed to match expected values for class %r" % class_)
 
     def test_not_fitted(self):
         for class_ in complexities.ALL_CLASSES:


### PR DESCRIPTION
The major fix in this PR is changes to the complexity classes to fix #43 and make sure `Polynomial.compute()` and `Exponential.compute()` return sensible values. Test cases are added for this and some other changes.

### Major Fix: Compute() make aware of time transform
The `compute()` function on `big_o.complexities.Polynomial()` and `big_o.complexities.Exponential()` fail because
these classes implement custom `_transform_time()` functions that alter the coefficients as calculated.
https://github.com/pberkes/big_O/blob/82b8bb318f93a8b7664d989ec069973291929823/big_o/complexities.py#L176-L177

However, the `compute()` function does not seem to account for `_transform_time()`.

This PR addresses the issue by introducing the `_inverse_transform_time()` function and calling it within `compute()` to correct the mathematical function.

### Test Cases
The `compute()` function already has test cases, but they seem to miss this issue because only `Linear` is tested.

https://github.com/pberkes/big_O/blob/82b8bb318f93a8b7664d989ec069973291929823/big_o/test/test_complexities.py#L10-L15

This PR adds test cases for all of the included complexity classes.

This PR also replaces the `numpy.testing.assert_array_almost_equal()` with `numpy.testing.assert_allclose()`.
The reason is `assert_array_almost_equal()` does not scale well for large floating point numbers, as is noted in [Numpy's documentation](https://numpy.org/doc/stable/reference/generated/numpy.testing.assert_array_almost_equal.html).

If `assert_array_almost_equal()` where used with the new test cases, the tests would fail due to the lost in precision in large floating point numbers.

### Other Changes

- Expanded `TestComplexities.test_not_fitted` to test all complexity classes, not just `Linear`

- Added `coefficients()` function to Polynomial classes to correct displaying the coefficients in there standard form, instead of the coefficient transformed by `_transform_time()` and `_transform_n()`. Previously printing a Polynomial or Exponential class would show incorrect coefficients.

- Change printing behavior from `"Polynomial: : not yet fitted"` to `"Polynomial: not yet fitted"`