### PR TITLE
Residual Calculation Fix and Miscellaneous Improvements

### DIFF
--- a/big_o/big_o.py
+++ b/big_o/big_o.py
@@ -62,7 +62,7 @@ def measure_execution_time(func, data_generator,
     return ns, execution_time
 
 
-def infer_big_o_class(ns, time, classes=ALL_CLASSES, verbose=False):
+def infer_big_o_class(ns, time, classes=ALL_CLASSES, verbose=False, simplicity_bias=1e-6):
     """Infer the complexity class from execution times.
 
     Input:
@@ -78,6 +78,12 @@ def infer_big_o_class(ns, time, classes=ALL_CLASSES, verbose=False):
 
     verbose -- If True, print parameters and residuals of the fit for each
                complexity class
+
+    simplicity_bias -- Preference toward choosing simpler methods when
+                       the difference between residuals is less than the
+                       simplicity_bias. If simplicity_bias is 0, the
+                       complexity class with the lowest residuals is
+                       always chosen.
 
     Output:
     -------
@@ -97,9 +103,9 @@ def infer_big_o_class(ns, time, classes=ALL_CLASSES, verbose=False):
         residuals = inst.fit(ns, time)
         fitted[inst] = residuals
 
-        # NOTE: subtract 1e-6 for tiny preference for simpler methods
+        # NOTE: subtract bias for tiny preference for simpler methods
         # TODO: improve simplicity bias (AIC/BIC)?
-        if residuals < best_residuals - 1e-6:
+        if residuals < best_residuals - simplicity_bias:
             best_residuals = residuals
             best_class = inst
         if verbose:
@@ -141,10 +147,10 @@ def big_o(func, data_generator,
     verbose -- If True, print parameters and residuals of the fit for each
                complexity class
 
-    return_raw_data -- If True, the function returns the measure points and its 
+    return_raw_data -- If True, the function returns the measure points and its
                        corresponding execution times as part of the fitted dictionary
-                       of complexity classes. When this flag is true, fitted will 
-                       contain the entries: 
+                       of complexity classes. When this flag is true, fitted will
+                       contain the entries:
                        {... 'measures': [<int>+], 'times': [<float>+] ...}
 
     Output:

--- a/big_o/complexities.py
+++ b/big_o/complexities.py
@@ -32,6 +32,9 @@ class ComplexityClass(object):
 
         residuals -- Sum of square errors of fit
         """
+        n = np.asanyarray(n)
+        t = np.asanyarray(t)
+
         x = self._transform_n(n)
         y = self._transform_time(t)
         coeff, residuals, rank, s = np.linalg.lstsq(x, y, rcond=-1)

--- a/big_o/complexities.py
+++ b/big_o/complexities.py
@@ -10,7 +10,14 @@ class NotFittedError(Exception):
 class ComplexityClass(object):
     """ Abstract class that fits complexity classes to timing data.
     """
-    _recalculate_residuals = False
+
+    #: bool: _recalculate_fit_residuals controls if the residuals value
+    # returned from np.linalg.lstsq() is equivalent to the margin of
+    # error of the found coefficients.
+    #
+    # This is normally only needed if the complexity class overrides
+    # _transform_time() or _inverse_transform_time()
+    _recalculate_fit_residuals = False
 
     def __init__(self):
         # list of parameters of the fitted function class as returned by the
@@ -42,7 +49,7 @@ class ComplexityClass(object):
 
         # Check if residuals from least square can be used, or if it
         # must be explicitly calculated.
-        if self._recalculate_residuals:
+        if self._recalculate_fit_residuals:
             ref_t = self.compute(n)
             residuals = np.sum((ref_t - t) ** 2)
         else:
@@ -195,7 +202,7 @@ class Linearithmic(ComplexityClass):
 class Polynomial(ComplexityClass):
     order = 70
 
-    _recalculate_residuals = True
+    _recalculate_fit_residuals = True
 
     def _transform_n(self, n):
         return np.vstack([np.ones(len(n)), np.log(n)]).T
@@ -227,7 +234,7 @@ class Polynomial(ComplexityClass):
 class Exponential(ComplexityClass):
     order = 80
 
-    _recalculate_residuals = True
+    _recalculate_fit_residuals = True
 
     def _transform_n(self, n):
         return np.vstack([np.ones(len(n)), n]).T

--- a/big_o/test/test_big_o.py
+++ b/big_o/test/test_big_o.py
@@ -7,6 +7,22 @@ import big_o
 from big_o import datagen
 from big_o import complexities as compl
 
+def dummy_linear_function(n):
+    # Dummy operation with linear complexity.
+    x = 0
+    for i in range(n):
+        for j in range(20):
+            x += 1
+    return x // 20
+
+def dummy_quadratic_function(n):
+    # Dummy operation with quadratic complexity.
+    x = 0
+    for i in range(n):
+        for j in range(n):
+            for k in range(20):
+                x += 1
+    return x // 20
 
 class TestBigO(unittest.TestCase):
 
@@ -42,30 +58,18 @@ class TestBigO(unittest.TestCase):
             assert_array_almost_equal(coeff, res_class.coeff, 2)
 
     def test_big_o(self):
-        def dummy_linear_function(n):
-            for i in range(n):
-                # Dummy operation with linear complexity.
-                8282828 * 2322
-
-        def dummy_quadratic_function(n):
-            for i in range(n):
-                for j in range(n):
-                    # Dummy operation with quadratic complexity.
-                    8282828 * 2322
-
-        # In the best case, TimSort is linear, so we fix a random array to
-        # make sure we hit a close-to-worst case scenario, which is
-        # O(n*log(n)).
-        random_state = np.random.RandomState(89342787)
+        # Numpy sorts are fast enough that they are very close to linear
+        # In testing, heapsort was found to follow the best clear n * log(n) curve
+        random_state = np.random.RandomState()
         random_array = random_state.rand(100000)
 
         # Each test case is a tuple
         # (function_to_evaluate, expected_complexity_class, range_for_n)
         desired = [
-            (dummy_linear_function, compl.Linear, (100, 10000)),
+            (dummy_linear_function, compl.Linear, (100, 1000)),
             (lambda n: 1., compl.Constant, (1000, 10000)),
-            (dummy_quadratic_function, compl.Quadratic, (50, 500)),
-            (lambda n: np.sort(random_array[:n], kind='mergesort'),
+            (dummy_quadratic_function, compl.Quadratic, (1, 100)),
+            (lambda n: np.sort(random_array[:n], kind='heapsort'),
              compl.Linearithmic, (100, random_array.shape[0])),
         ]
         for func, class_, n_range in desired:
@@ -76,41 +80,40 @@ class TestBigO(unittest.TestCase):
                 n_measures=25,
                 n_repeats=10,
                 n_timings=10,
-            )
-            self.assertEqual(class_, res_class.__class__)
+                return_raw_data = True)
+
+            residuals = fitted[res_class]
+
+            if residuals > 5e-4:
+                if isinstance(res_class, class_):
+                    self.skipTest("Complexity fit error is too high to be reliable (but test passed)")
+                else:
+                    self.skipTest("Complexity fit error is too high to be reliable (and test failed)")
+
+            sol_class, sol_residuals = next(
+                (complexity, residuals) for complexity, residuals in fitted.items()
+                if isinstance(complexity, class_))
+
+            self.assertIsInstance(res_class, class_,
+                msg = "Best matched complexity is {} (r={:f}) when {} (r={:f}) was expected"
+                    .format(res_class, residuals, sol_class, sol_residuals))
 
     def test_big_o_return_raw_data_default(self):
-        def dummy_linear_function(n):
-            for _ in range(n):
-                # Dummy operation with constant complexity.
-                8282828 * 2322
-
         _, fitted = big_o.big_o(
             dummy_linear_function,
             datagen.n_,
-            min_n=100,
-            max_n=10000,
-            n_measures=25,
-            n_repeats=10,
-            n_timings=10)
+            min_n=10,
+            max_n=1000)
 
         for _, v in fitted.items():
             self.assertIsInstance(v, np.float64)
 
     def test_big_o_return_raw_data_false(self):
-        def dummy_linear_function(n):
-            for _ in range(n):
-                # Dummy operation with constant complexity.
-                8282828 * 2322
-
         _, fitted = big_o.big_o(
             dummy_linear_function,
             datagen.n_,
-            min_n=100,
-            max_n=10000,
-            n_measures=25,
-            n_repeats=10,
-            n_timings=10,
+            min_n=10,
+            max_n=1000,
             return_raw_data=False)
 
         for _, v in fitted.items():

--- a/big_o/test/test_big_o.py
+++ b/big_o/test/test_big_o.py
@@ -7,8 +7,19 @@ import big_o
 from big_o import datagen
 from big_o import complexities as compl
 
+def dummy_constant_function(n):
+    # Dummy operation with constant complexity.
+    x = 0
+    for i in range(100):
+        x += 1
+    return n
+
 def dummy_linear_function(n):
     # Dummy operation with linear complexity.
+
+    # Constant component of linear function
+    dummy_constant_function(n)
+
     x = 0
     for i in range(n):
         for j in range(20):
@@ -17,6 +28,10 @@ def dummy_linear_function(n):
 
 def dummy_quadratic_function(n):
     # Dummy operation with quadratic complexity.
+
+    # Constant component of quadratic function
+    dummy_constant_function(n)
+
     x = 0
     for i in range(n):
         for j in range(n):
@@ -83,8 +98,8 @@ class TestBigO(unittest.TestCase):
         # Each test case is a tuple
         # (function_to_evaluate, expected_complexity_class, range_for_n)
         desired = [
-            (dummy_linear_function, compl.Linear, (100, 1000)),
-            (lambda n: 1., compl.Constant, (1000, 10000)),
+            (dummy_constant_function, compl.Constant, (1000, 10000)),
+            (dummy_linear_function, compl.Linear, (100, 2000)),
             (dummy_quadratic_function, compl.Quadratic, (1, 100)),
             (lambda n: np.sort(random_array[:n], kind='heapsort'),
              compl.Linearithmic, (100, random_array.shape[0])),
@@ -101,7 +116,7 @@ class TestBigO(unittest.TestCase):
 
             residuals = fitted[res_class]
 
-            if residuals > 1e-4:
+            if residuals > 5e-4:
                 if isinstance(res_class, class_):
                     self.skipTest("Complexity fit error is too high to be reliable (but test passed)")
                 else:

--- a/big_o/test/test_big_o.py
+++ b/big_o/test/test_big_o.py
@@ -122,9 +122,16 @@ class TestBigO(unittest.TestCase):
 
             if residuals > 5e-4:
                 if isinstance(res_class, class_):
-                    self.skipTest("Complexity fit error is too high to be reliable (but test passed)")
+                    err_msg = "(but test would have passed)"
                 else:
-                    self.skipTest("Complexity fit error is too high to be reliable (and test failed)")
+                    err_msg = "(and test would have failed)"
+
+                # Residual value is too high
+                # This is likely caused by the CPU being too noisy with other processes
+                # that is preventing clean timing results.
+                self.fail(
+                    "Complexity fit residuals ({:f}) is too high to be reliable {}"
+                    .format(residuals, err_msg))
 
             sol_class, sol_residuals = next(
                 (complexity, residuals) for complexity, residuals in fitted.items()

--- a/big_o/test/test_big_o.py
+++ b/big_o/test/test_big_o.py
@@ -32,7 +32,7 @@ class TestBigO(unittest.TestCase):
             return n
         ns, t = big_o.measure_execution_time(
             f, datagen.n_,
-            min_n=1, max_n=5, n_measures=5, n_repeats=1,
+            min_n=1, max_n=5, n_measures=5, n_repeats=1, n_timings=5
         )
         assert_array_equal(ns, np.arange(1, 6))
         assert_array_almost_equal(t*10., np.arange(1, 6), 1)
@@ -56,6 +56,23 @@ class TestBigO(unittest.TestCase):
             res_class, fitted = big_o.infer_big_o_class(x, y)
             self.assertEqual(class_, res_class.__class__)
             assert_array_almost_equal(coeff, res_class.coeff, 2)
+
+    def test_infer_big_o_list_input(self):
+        # Check a normal list / iterable can be passed to infer_big_o_class()
+        ns = range(10, 100, 10)
+        time = [x**2 for x in ns]
+
+        best, fitted = big_o.infer_big_o_class(ns, time)
+
+        ns_np = np.array(ns)
+        time_np = np.array(time)
+
+        best_check, fitted_check = big_o.infer_big_o_class(ns_np, time_np)
+
+        self.assertEqual(best.order, best_check.order,
+            msg = "Order of complexity {} did not match check complexity {}".format(
+                best, best_check))
+        self.assertAlmostEqual(fitted[best], fitted_check[best_check])
 
     def test_big_o(self):
         # Numpy sorts are fast enough that they are very close to linear
@@ -84,7 +101,7 @@ class TestBigO(unittest.TestCase):
 
             residuals = fitted[res_class]
 
-            if residuals > 5e-4:
+            if residuals > 1e-4:
                 if isinstance(res_class, class_):
                     self.skipTest("Complexity fit error is too high to be reliable (but test passed)")
                 else:

--- a/big_o/test/test_big_o.py
+++ b/big_o/test/test_big_o.py
@@ -7,12 +7,14 @@ import big_o
 from big_o import datagen
 from big_o import complexities as compl
 
+
 def dummy_constant_function(n):
     # Dummy operation with constant complexity.
     x = 0
     for i in range(100):
         x += 1
     return n
+
 
 def dummy_linear_function(n):
     # Dummy operation with linear complexity.
@@ -26,6 +28,7 @@ def dummy_linear_function(n):
             x += 1
     return x // 20
 
+
 def dummy_quadratic_function(n):
     # Dummy operation with quadratic complexity.
 
@@ -38,6 +41,7 @@ def dummy_quadratic_function(n):
             for k in range(20):
                 x += 1
     return x // 20
+
 
 class TestBigO(unittest.TestCase):
 
@@ -99,7 +103,7 @@ class TestBigO(unittest.TestCase):
         # (function_to_evaluate, expected_complexity_class, range_for_n)
         desired = [
             (dummy_constant_function, compl.Constant, (1000, 10000)),
-            (dummy_linear_function, compl.Linear, (100, 2000)),
+            (dummy_linear_function, compl.Linear, (100, 5000)),
             (dummy_quadratic_function, compl.Quadratic, (1, 100)),
             (lambda n: np.sort(random_array[:n], kind='heapsort'),
              compl.Linearithmic, (100, random_array.shape[0])),

--- a/big_o/test/test_complexities.py
+++ b/big_o/test/test_complexities.py
@@ -46,3 +46,30 @@ class TestComplexities(unittest.TestCase):
         linear.fit(x, y)
         linear_str = str(linear)
         assert '(sec)' in linear_str
+
+    def test_fit_list_input(self):
+        # Check a normal list / iterable can be passed to fit()
+        ns = range(10, 100, 10)
+        time = [x**2 for x in ns]
+
+        quadratic = complexities.Quadratic()
+        quadratic.fit(ns, time)
+
+        coeff = quadratic.coeff
+        coefficients = quadratic.coefficients()
+
+        ns_np = np.array(ns)
+        time_np = np.array(time)
+
+        quadratic_check = complexities.Quadratic()
+        quadratic_check.fit(ns_np, time_np)
+
+        coeff_check = quadratic_check.coeff
+        coefficients_check = quadratic_check.coefficients()
+
+        assert_allclose(coeff, coeff_check,
+            err_msg = "coeff of {} did not match coeff of check complexity {}".format(
+                quadratic, quadratic_check))
+        assert_allclose(coefficients, coefficients_check,
+            err_msg = "coefficients of {} did not match coefficients of check complexity {}".format(
+                quadratic, quadratic_check))

--- a/big_o/test/test_complexities.py
+++ b/big_o/test/test_complexities.py
@@ -23,9 +23,17 @@ class TestComplexities(unittest.TestCase):
         for f, class_ in desired:
             y = f(x)
             complexity = class_()
-            complexity.fit(x, y)
-            assert_allclose(y, complexity.compute(x),
+            residuals = complexity.fit(x, y)
+
+            ref_y = complexity.compute(x)
+            assert_allclose(y, ref_y,
                 err_msg = "compute() failed to match expected values for class %r" % class_)
+
+            # Check residuals are correct
+            # Use the atol constant from np.allclose() because the default for
+            # np.testing.assert_allclose() for atol (0) is too low for this comparison
+            assert_allclose(residuals, np.sum((y - ref_y) ** 2), rtol=1e-07, atol=1e-08,
+                err_msg = "compute() residuals failed to match expected values for class %r" % class_)
 
     def test_not_fitted(self):
         for class_ in complexities.ALL_CLASSES:


### PR DESCRIPTION
Fixes an issue with how residuals are calculated and improves the reliability of test cases.

## Residual Calculation Fix

### tl;dr

The residual value returned from `np.linalg.lstsq(x, y, rcond=-1)` for Polynomial and
Exponential classes can not be meaningfully compared with the other complexity classes.

https://github.com/pberkes/big_O/blob/0ed1e3d2d4a74f3c2f41bb6b147d4a2231f8fcb3/big_o/complexities.py#L36

The issue is the transform used in Polynomial and Exponential complexity classes to correctly
generate the coefficients causes the residual calculation to be invalidated.

https://github.com/pberkes/big_O/blob/0ed1e3d2d4a74f3c2f41bb6b147d4a2231f8fcb3/big_o/complexities.py#L189-L190

The solution is to recalculate the residuals manually:
```python
ref_t = self.compute(n)
residuals = np.sum((ref_t - t) ** 2)
```
### Steps to Reproduce

Here is an example that demonstrates big_O misclassifying a quadratic function because of this issue.

```python
import big_o
import numpy as np
import matplotlib.pyplot as plt

# Set seed for consistent results
rng = np.random.default_rng(1234)

measures = np.linspace(1, 10, 100)

# Quadratic Function
func = lambda x: x**2

# Add randomness so its not exactly a quadratic
times = func(measures + np.abs(rng.standard_normal(measures.size)) * .1) + np.abs(rng.standard_normal(measures.size))

# Run big_o to get the best result
best, fitted = big_o.infer_big_o_class(measures, times, verbose = True)
# Observe best is *not* quadatic

# Lookup the fitted function for quadratic and exponential
quadatic = next(complexity for complexity in fitted if isinstance(complexity, big_o.complexities.Quadratic))
exponential = next(complexity for complexity in fitted if isinstance(complexity, big_o.complexities.Exponential))

# Plot the "best", second best, and the actual solution
plt.plot(measures, times, "-", label = "Original")
plt.plot(measures, best.compute(measures), "--", label = "Best " + str(best))
plt.plot(measures, quadatic.compute(measures), "--", label = quadatic)
plt.plot(measures, exponential.compute(measures), "--", label = exponential)
plt.xlabel("n")
plt.ylabel("t (sec)")
plt.legend()
plt.show()
```

```
Constant: time = 39 (sec) (r=90378.409421)
Linear: time = -23 + 11*n (sec) (r=4052.834495)
Quadratic: time = 1.2 + 1*n^2 (sec) (r=89.693176)
Cubic: time = 10 + 0.1*n^3 (sec) (r=2269.462214)
Polynomial: time = 1.6 * x^1.8 (sec) (r=1.323089)
Logarithmic: time = -30 + 45*log(n) (sec) (r=19352.077840)
Linearithmic: time = -4.4 + 4.3*n*log(n) (sec) (r=1389.322845)
Exponential: time = 2.8 * 1.5^n (sec) (r=6.137839)
```

As for can see in the calculated residuals, the best matching functions should be Polynomial with a residual of `1.32`, followed by Exponential with a residual of `6.14`, and followed distantly by Quadratic with a residual `89.70`.
This is surprising, since the original function is Quadratic, yet Polynomial and Exponential were found to be better matches.

If we look at the graph, we can see this is an issue.

![Big O Graph Demonstrating Classification Bug](https://user-images.githubusercontent.com/22862051/185802748-ec68955d-71b7-4d5d-94d2-1bae137021df.png)

Blue is the original function.
Green is the Quadratic complexity, which seems to match the original input quite well.
Orange is the Polynomial complexity, which seems to trail off of the original function at the tail end.
Red is Exponential complexity, which does not seem to match the original function very well at all, yet had a lower residual than Quadratic.

This is an issue. `big_o.infer_big_o_class` should have identified Quadratic as the best complexity.

### The Math
```python
coeff, residuals, rank, s = np.linalg.lstsq(x, y, rcond=-1)
```

$n_i$ is the input measurement ($i$ is the index for multiple measurements)

$t_i$ is the time measured for the cooresponding $n_i$

For each complexity, there are functions $F(n_i)$ and $T(t_i)$ that transforms $n_i$
and $t_i$ before they are passed to `np.linalg.lstsq()`.

The result of `np.linalg.lstsq()` are `coeff`, which is referenced as $c$ and `residuals`
which is referenced at $r$.

The other outputs from `np.linalg.lstsq()` are unused.

$$x_i = F(n_i)$$
$$y_i = T(t_i)$$

| Complexity   |   $F(n)$ |  $T(t)$ | $T^-1(t')$ |
|--------------|----------|---------|-----------|
| Constant     |      $1$ |     $t$ |       $t$ |
| Linear       |      $n$ |     $t$ |       $t$ |
| Quadratic    |    $n^2$ |     $t$ |       $t$ |
| Cubic        |    $n^3$ |     $t$ |       $t$ |
| Logarithmic  |  $ln(n)$ |     $t$ |       $t$ |
| Linearithmic | $nln(n)$ |     $t$ |       $t$ |
| Polynomial   |  $ln(n)$ | $ln(t)$ |     $e^t$ |
| Exponential  |      $n$ | $ln(t)$ |     $e^t$ |

The residual from `np.linalg.lstsq()` is calculated as the sum of squares of the calculated coefficiences.

$$t_i' = c_{1}F(n_i)+c_0$$

This can be expressed by the following equation for a given $F(n_i)$ and $T(t_i)$ with the resulting coefficience $c$:

$$r=\sum_{i=0}^{k}(t_i'-T(t_i))^2$$

_However_ the equation for error, the distance between the equation represented by the complexity and the inputted function is calculated by applying $T^{-1}(t')$ to $t_i'$ instead of applying $T(t)$ to $t_i$.

$$s=\sum_{i=0}^{k}(T^{-1}(t_i')-t_i)^2$$

For must of the complexity functions, where $T(t) = t$, this error calculation is equal to the residual calculation.

But these are not equal for Polynomial and Exponential. This is shown in the table below:

<br></br>

| Complexity   | Residual                           | Error                              | Residual = Error |
|--------------|------------------------------------|------------------------------------|------------------|
| Constant     | $$\sum_{i=0}^{k}(t_i'-t_i)^2$$     | $$\sum_{i=0}^{k}(t_i'-t_i)^2$$     | ✅               |
| Linear       | $$\sum_{i=0}^{k}(t_i'-t_i)^2$$     | $$\sum_{i=0}^{k}(t_i'-t_i)^2$$     | ✅               |
| Quadratic    | $$\sum_{i=0}^{k}(t_i'-t_i)^2$$     | $$\sum_{i=0}^{k}(t_i'-t_i)^2$$     | ✅               |
| Cubic        | $$\sum_{i=0}^{k}(t_i'-t_i)^2$$     | $$\sum_{i=0}^{k}(t_i'-t_i)^2$$     | ✅               |
| Logarithmic  | $$\sum_{i=0}^{k}(t_i'-t_i)^2$$     | $$\sum_{i=0}^{k}(t_i'-t_i)^2$$     | ✅               |
| Linearithmic | $$\sum_{i=0}^{k}(t_i'-t_i)^2$$     | $$\sum_{i=0}^{k}(t_i'-t_i)^2$$     | ✅               |
| Polynomial   | $$\sum_{i=0}^{k}(t_i'-ln(t_i))^2$$ | $$\sum_{i=0}^{k}(e^{t_i'}-t_i)^2$$ | ❌               |
| Exponential  | $$\sum_{i=0}^{k}(t_i'-ln(t_i))^2$$ | $$\sum_{i=0}^{k}(e^{t_i'}-t_i)^2$$ | ❌               |

So for Polynomial and Exponential, the residual must be recalculated to be equal to the error.

## Test Cases Improvements

From testing, it seems that specifically the test `big_o.test.test_big_o.TestBigO` seems to fail often.

```
% python -m unittest -v
test_big_o (big_o.test.test_big_o.TestBigO) ... FAIL
test_big_o_return_raw_data_default (big_o.test.test_big_o.TestBigO) ... ok
test_big_o_return_raw_data_false (big_o.test.test_big_o.TestBigO) ... ok
test_big_o_return_raw_data_true (big_o.test.test_big_o.TestBigO) ... ok
test_infer_big_o (big_o.test.test_big_o.TestBigO) ... ok
test_measure_execution_time (big_o.test.test_big_o.TestBigO) ... ok
test_compute (big_o.test.test_complexities.TestComplexities) ... ok
test_not_fitted (big_o.test.test_complexities.TestComplexities) ... ok
test_str_includes_units (big_o.test.test_complexities.TestComplexities) ... ok
test_eq (big_o.test.test_complexityclass_comparisons.TestComplexities) ... ok
test_g (big_o.test.test_complexityclass_comparisons.TestComplexities) ... ok
test_ge (big_o.test.test_complexityclass_comparisons.TestComplexities) ... ok
test_l (big_o.test.test_complexityclass_comparisons.TestComplexities) ... ok
test_le (big_o.test.test_complexityclass_comparisons.TestComplexities) ... ok

======================================================================
FAIL: test_big_o (big_o.test.test_big_o.TestBigO)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "big_O/big_o/test/test_big_o.py", line 80, in test_big_o
    self.assertEqual(class_, res_class.__class__)
AssertionError: <class 'big_o.complexities.Quadratic'> != <class 'big_o.complexities.Cubic'>

----------------------------------------------------------------------
Ran 14 tests in 8.803s
```

In testing, I found this test passed in 29 out of 100 tests.
Specs below:
 - Python 3.10.6
 - MacOS 12.4
 - MacBook Air 2017
 - I7-5650U (Frequency limited to 2.2 GHz in software)
 - On battery power

The problem appears to be the quadratic function being used for testing is too fast for
accurate timing to be achieved.

The code being used is:

https://github.com/pberkes/big_O/blob/0ed1e3d2d4a74f3c2f41bb6b147d4a2231f8fcb3/big_o/test/test_big_o.py#L50-L54

The problem with this function, is Python optimizes out the multiplication, leaving only two empty loops.

This can be demonstrated by using [dis](https://docs.python.org/3/library/dis.html) to look at the disassembly:

```python
>>> def dummy_quadratic_function(n): 
...      for i in range(n): 
...          for j in range(n): 
...              # Dummy operation with quadratic complexity. 
...              8282828 * 2322
... 
>>> import dis
>>> dis.dis(dummy_quadratic_function)
  2           0 LOAD_GLOBAL              0 (range)
              2 LOAD_FAST                0 (n)
              4 CALL_FUNCTION            1
              6 GET_ITER
        >>    8 FOR_ITER                 9 (to 28)
             10 STORE_FAST               1 (i)

  3          12 LOAD_GLOBAL              0 (range)
             14 LOAD_FAST                0 (n)
             16 CALL_FUNCTION            1
             18 GET_ITER
        >>   20 FOR_ITER                 2 (to 26)
             22 STORE_FAST               2 (j)

  5          24 JUMP_ABSOLUTE           10 (to 20)

  3     >>   26 JUMP_ABSOLUTE            4 (to 8)

  2     >>   28 LOAD_CONST               0 (None)
             30 RETURN_VALUE
```
Python has optimized the function down to just the two for loops, which is fast enough to cause the classification to be inconsistent.

This is fixed by saving the results to variables, and doing some simple addition.
It also adds a constant component
```python
def dummy_quadratic_function(n):
    # Dummy operation with quadratic complexity.

    # Constant component of quadratic function
    dummy_constant_function(n)

    x = 0
    for i in range(n):
        for j in range(n):
            for k in range(20):
                x += 1
    return x // 20
```

## Other Improvements

### Simplicity Bias
Add `simplicity_bias` as a parameter of `big_o.infer_big_o_class()` to allow for the user to change the bias to choosing a simpler complexity when the residuals are close.

https://github.com/pberkes/big_O/blob/0ed1e3d2d4a74f3c2f41bb6b147d4a2231f8fcb3/big_o/big_o.py#L102

#### `big_o.test.test_big_o.TestBigO.test_big_o()` Change Numpy sort to `heapsort` from `mergesort`

As reflected in the comments `mergesort` can appear like a more linear function depending on the input set.

https://github.com/pberkes/big_O/blob/0ed1e3d2d4a74f3c2f41bb6b147d4a2231f8fcb3/big_o/test/test_big_o.py#L56-L60

The Numpy documentation shows a possible reason for this, that the merge sort may be implemented by a radix sort or Tim sort. Radix sort is a linear time sorting algorithm and Tim sort, under the right situation, can appear to be a linear sorting algorithm.

https://numpy.org/doc/stable/reference/generated/numpy.sort.html
> Note that both ‘stable’ and ‘mergesort’ use timsort or radix sort under the covers

This commit changes the sort to a heap sort, which is reliable enough that it is not necessary to set the random order of the list that is sorted.

#### `big_o.test.test_big_o.TestBigO.test_measure_execution_time()` set `n_timings` to `5` for more reliable testing

https://github.com/pberkes/big_O/blob/0ed1e3d2d4a74f3c2f41bb6b147d4a2231f8fcb3/big_o/test/test_big_o.py#L17-L20

It appears that the test is more reliable if the timing is run multiple times, which is done by setting `n_timings=5`

#### Allow list parameters to passed to `complexity.fit()`

Currently `ComplexityClass.fit()` requires two Numpy arrays to be passed as arguments.
However, that often requires the calling code needs to explicitly import Numpy to create the arrays.

This PR adds a call to `np.asanyarray()` to the inputs in `complexity.fit()` so calling code can specify inputs as normal Python iterables.

Test cases for this are included.